### PR TITLE
Support sequence modifiers and tighten left recursion checks

### DIFF
--- a/macros/examples/lang.rs
+++ b/macros/examples/lang.rs
@@ -4,7 +4,6 @@ extern crate macros;
 extern crate lr;
 
 fn main() {
-
     macros::parser1! {
         Plus = "+";
         Minus = "-";


### PR DESCRIPTION
## Summary
- allow the sequence parser to accept `+`, `*`, and `[]` modifiers and plumb helper utilities to reason about optional/empty prefixes
- update left recursion detection to account for emptyable prefixes and bail out on unsupported shapes, including coverage tests for the new behaviour
- run rustfmt on the macro crate for the touched code paths

## Testing
- cargo test
- cargo test (macros)


------
https://chatgpt.com/codex/tasks/task_e_68e433429d9883208b1a2108191f7282